### PR TITLE
Support skipCsf option in compile functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,9 @@ import mdx from '@mdx-js/mdx';
 import { createCompiler, MdxOptions } from './sb-mdx-plugin';
 
 export const compile = async (code: string, options?: MdxOptions) =>
-  mdx(code, { compilers: [createCompiler(options)] });
+  mdx(code, { compilers: options.skipCsf ? undefined : [createCompiler(options)] });
 
 export const compileSync = (code: string, options?: MdxOptions) =>
-  mdx.sync(code, { compilers: [createCompiler(options)] });
+  mdx.sync(code, { compilers: options.skipCsf ? undefined : [createCompiler(options)] });
 
 export * from './sb-mdx-plugin';

--- a/src/sb-mdx-plugin.ts
+++ b/src/sb-mdx-plugin.ts
@@ -14,6 +14,7 @@ export interface MdxOptions {
   wrapExport?: string;
   remarkPlugins?: any[];
   rehypePlugins?: any[];
+  skipCsf?: boolean;
 }
 
 interface CompilerOptions {


### PR DESCRIPTION
Issue: #

## What Changed

<!-- Insert a description below. -->

This will allow the vite builder to use the compile function on non-story mdx files.

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->

## Change Type

<!-- Indicate the type of change your pull request is: -->

- [ ] `maintenance`
- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`
