### PR TITLE
Add missing peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "build-storybook": "build-storybook"
   },
   "dependencies": {
+    "@babel/core": "^7.12.3",
     "@babel/generator": "^7.12.11",
     "@babel/parser": "^7.12.11",
     "@babel/preset-env": "^7.12.11",
@@ -52,7 +53,6 @@
   "devDependencies": {
     "@auto-it/released": "^10.32.6",
     "@babel/cli": "^7.12.1",
-    "@babel/core": "^7.12.3",
     "@babel/preset-env": "^7.12.1",
     "@babel/preset-react": "^7.12.5",
     "@babel/preset-typescript": "^7.13.0",


### PR DESCRIPTION
Issue: N/A

## What Changed

Fixed this [implicit transitive peer dependency](https://dev.to/arcanis/implicit-transitive-peer-dependencies-ed0) warnings:
```
➤ YN0002: │ @storybook/mdx1-csf@npm:0.0.1 doesn't provide @babel/core (pca7e3), requested by @babel/preset-env
```

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->

## Change Type

<!-- Indicate the type of change your pull request is: -->

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
