### PR TITLE
Move libs used in tests to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,15 +45,12 @@
     "@types/lodash": "^4.14.167",
     "js-string-escape": "^1.0.1",
     "loader-utils": "^2.0.0",
-    "lodash": "^4.17.21",
-    "prettier": ">=2.2.1 <=2.3.0",
-    "ts-dedent": "^2.0.0"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@auto-it/released": "^10.32.6",
     "@babel/cli": "^7.12.1",
     "@babel/core": "^7.12.3",
-    "@babel/preset-env": "^7.12.1",
     "@babel/preset-react": "^7.12.5",
     "@babel/preset-typescript": "^7.13.0",
     "@babel/template": "^7.14.5",
@@ -80,6 +77,7 @@
     "jest": "^27.0.6",
     "jest-environment-jsdom": "^27.0.6",
     "lint-staged": ">=10",
+    "prettier": ">=2.2.1 <=2.3.0",
     "prompts": "^2.4.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",


### PR DESCRIPTION
## What Changed

Moves a few development dependencies (modules used only in tests) to `devDependencies`, and remove `@babel/preset-env` from `devDependencies` because it's already in `dependencies`. 

## How to test

Run existing tests as normal. The behavior should not change in any way. 

Once released the library should no longer create a dependency for `prettier` or `ts-dedent` in the utilizing project.

## Change Type

<!-- Indicate the type of change your pull request is: -->

- [x] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
