### PR TITLE
Remove uses of `AddContext`

### DIFF
--- a/src/sb-mdx-plugin.test.ts
+++ b/src/sb-mdx-plugin.test.ts
@@ -70,8 +70,6 @@ describe('docs-mdx-compiler-plugin', () => {
         },
         includeStories: ['componentNotes'],
       };
-
-      const mdxStoryNameToKey = { 'component notes': 'componentNotes' };
     `);
   });
 
@@ -98,8 +96,6 @@ describe('docs-mdx-compiler-plugin', () => {
         component: Button,
         includeStories: ['componentNotes'],
       };
-
-      const mdxStoryNameToKey = { 'component notes': 'componentNotes' };
     `);
   });
 
@@ -132,8 +128,6 @@ describe('docs-mdx-compiler-plugin', () => {
       _Foo_.storyName = 'renamed';
 
       const componentMeta = { title: 'MDX/CSF imports', includeStories: ['_Basic_', '_Other_', '_Foo_'] };
-
-      const mdxStoryNameToKey = { _Basic_: '_Basic_', _Other_: '_Other_', renamed: '_Foo_' };
     `);
   });
 
@@ -175,8 +169,6 @@ describe('docs-mdx-compiler-plugin', () => {
         ],
         includeStories: ['one'],
       };
-
-      const mdxStoryNameToKey = { one: 'one' };
     `);
   });
 
@@ -199,8 +191,6 @@ describe('docs-mdx-compiler-plugin', () => {
       __page.parameters = { docsOnly: true };
 
       const componentMeta = { title: 'docs-only', includeStories: ['__page'] };
-
-      const mdxStoryNameToKey = {};
     `);
   });
 
@@ -237,8 +227,6 @@ describe('docs-mdx-compiler-plugin', () => {
         ],
         includeStories: ['one'],
       };
-
-      const mdxStoryNameToKey = { one: 'one' };
     `);
   });
 
@@ -257,8 +245,6 @@ describe('docs-mdx-compiler-plugin', () => {
       __page.parameters = { docsOnly: true };
 
       const componentMeta = { title: "Addons/Docs/what's in a title?", includeStories: ['__page'] };
-
-      const mdxStoryNameToKey = {};
     `);
   });
 
@@ -292,8 +278,6 @@ describe('docs-mdx-compiler-plugin', () => {
       helloStory.parameters = { storySource: { source: '<Button>Hello button</Button>' } };
 
       const componentMeta = { title: 'Button', includeStories: ['one', 'helloStory'] };
-
-      const mdxStoryNameToKey = { one: 'one', 'hello story': 'helloStory' };
     `);
   });
 
@@ -335,8 +319,6 @@ describe('docs-mdx-compiler-plugin', () => {
         component: Button,
         includeStories: ['componentNotes', 'storyNotes'],
       };
-
-      const mdxStoryNameToKey = { 'component notes': 'componentNotes', 'story notes': 'storyNotes' };
     `);
   });
 
@@ -386,8 +368,6 @@ describe('docs-mdx-compiler-plugin', () => {
         component: Button,
         includeStories: ['helloButton', 'two'],
       };
-
-      const mdxStoryNameToKey = { 'hello button': 'helloButton', two: 'two' };
     `);
   });
 
@@ -429,8 +409,6 @@ describe('docs-mdx-compiler-plugin', () => {
       componentNotes.parameters = { storySource: { source: 'args => <Button>Component notes</Button>' } };
 
       const componentMeta = { title: 'Button', includeStories: ['componentNotes'] };
-
-      const mdxStoryNameToKey = { 'component notes': 'componentNotes' };
     `);
   });
 
@@ -443,11 +421,7 @@ describe('docs-mdx-compiler-plugin', () => {
 
         <Story id="." />
       `)
-    ).toMatchInlineSnapshot(`
-      const componentMeta = { includeStories: [] };
-
-      const mdxStoryNameToKey = {};
-    `);
+    ).toMatchInlineSnapshot(`const componentMeta = { includeStories: [] };`);
   });
 
   it('story-def-text-only.mdx', () => {
@@ -467,8 +441,6 @@ describe('docs-mdx-compiler-plugin', () => {
       text.parameters = { storySource: { source: "'Plain text'" } };
 
       const componentMeta = { title: 'Text', includeStories: ['text'] };
-
-      const mdxStoryNameToKey = { text: 'text' };
     `);
   });
 
@@ -519,13 +491,6 @@ describe('docs-mdx-compiler-plugin', () => {
         title: 'Button',
         includeStories: ['one', 'helloStory', 'wPunctuation', '_1FineDay'],
       };
-
-      const mdxStoryNameToKey = {
-        one: 'one',
-        'hello story': 'helloStory',
-        'w/punctuation': 'wPunctuation',
-        '1 fine day': '_1FineDay',
-      };
     `);
   });
 
@@ -550,8 +515,6 @@ describe('docs-mdx-compiler-plugin', () => {
       basic.parameters = { storySource: { source: 'basicFn' } };
 
       const componentMeta = { title: 'story-function-var', includeStories: ['basic'] };
-
-      const mdxStoryNameToKey = { basic: 'basic' };
     `);
   });
 
@@ -583,8 +546,6 @@ describe('docs-mdx-compiler-plugin', () => {
       };
 
       const componentMeta = { includeStories: ['functionStory'] };
-
-      const mdxStoryNameToKey = { function: 'functionStory' };
     `);
   });
 
@@ -615,8 +576,6 @@ describe('docs-mdx-compiler-plugin', () => {
       };
 
       const componentMeta = { title: 'Multiple', includeStories: ['multipleChildren'] };
-
-      const mdxStoryNameToKey = { 'multiple children': 'multipleChildren' };
     `);
   });
 
@@ -662,8 +621,6 @@ describe('docs-mdx-compiler-plugin', () => {
       };
 
       const componentMeta = { title: 'MDX|Welcome', includeStories: ['toStorybook'] };
-
-      const mdxStoryNameToKey = { 'to storybook': 'toStorybook' };
     `);
   });
 
@@ -676,11 +633,7 @@ describe('docs-mdx-compiler-plugin', () => {
 
         <Story id="welcome--welcome" />
       `)
-    ).toMatchInlineSnapshot(`
-      const componentMeta = { includeStories: [] };
-
-      const mdxStoryNameToKey = {};
-    `);
+    ).toMatchInlineSnapshot(`const componentMeta = { includeStories: [] };`);
   });
 
   it('title-template-string.mdx', () => {
@@ -702,8 +655,6 @@ describe('docs-mdx-compiler-plugin', () => {
       __page.parameters = { docsOnly: true };
 
       const componentMeta = { title: \`\${titleFunction('template')}\`, includeStories: ['__page'] };
-
-      const mdxStoryNameToKey = {};
     `);
   });
 
@@ -718,11 +669,7 @@ describe('docs-mdx-compiler-plugin', () => {
 
         <Button>Hello button</Button>
       `)
-    ).toMatchInlineSnapshot(`
-      const componentMeta = { includeStories: [] };
-
-      const mdxStoryNameToKey = {};
-    `);
+    ).toMatchInlineSnapshot(`const componentMeta = { includeStories: [] };`);
   });
 
   it('errors on missing story props', async () => {
@@ -754,11 +701,7 @@ describe('docs-mdx-compiler-plugin', () => {
 
           Spme **markdown** here!
         `)
-      ).toMatchInlineSnapshot(`
-        const componentMeta = { includeStories: [] };
-
-        const mdxStoryNameToKey = {};
-      `);
+      ).toMatchInlineSnapshot(`const componentMeta = { includeStories: [] };`);
     });
 
     it('auto-title.mdx', () => {
@@ -779,8 +722,6 @@ describe('docs-mdx-compiler-plugin', () => {
         basic.parameters = { storySource: { source: '<Button>Basic</Button>' } };
 
         const componentMeta = { component: Button, includeStories: ['basic'] };
-
-        const mdxStoryNameToKey = { Basic: 'basic' };
       `);
     });
 
@@ -800,8 +741,6 @@ describe('docs-mdx-compiler-plugin', () => {
         basic.parameters = { storySource: { source: '{}' } };
 
         const componentMeta = { title: 'Button', component: Button, includeStories: ['basic'] };
-
-        const mdxStoryNameToKey = { Basic: 'basic' };
       `);
     });
 
@@ -826,8 +765,6 @@ describe('docs-mdx-compiler-plugin', () => {
           render: (args) => <Button {...args} />,
           includeStories: ['basic'],
         };
-
-        const mdxStoryNameToKey = { Basic: 'basic' };
       `);
     });
 
@@ -848,8 +785,6 @@ describe('docs-mdx-compiler-plugin', () => {
         basic.render = (args) => <Button {...args} />;
 
         const componentMeta = { title: 'Button', component: Button, includeStories: ['basic'] };
-
-        const mdxStoryNameToKey = { Basic: 'basic' };
       `);
     });
 
@@ -870,8 +805,6 @@ describe('docs-mdx-compiler-plugin', () => {
         basic.play = () => console.log('play');
 
         const componentMeta = { title: 'Button', component: Button, includeStories: ['basic'] };
-
-        const mdxStoryNameToKey = { Basic: 'basic' };
       `);
     });
   });

--- a/src/sb-mdx-plugin.ts
+++ b/src/sb-mdx-plugin.ts
@@ -356,13 +356,11 @@ function getExports(node: Element, context: Context, options: CompilerOptions) {
   return null;
 }
 
-// insert `mdxStoryNameToKey` and `mdxComponentMeta` into the context so that we
-// can reconstruct the Story ID dynamically from the `name` at render time
 export const wrapperJs = `
 componentMeta.parameters = componentMeta.parameters || {};
 componentMeta.parameters.docs = {
   ...(componentMeta.parameters.docs || {}),
-  page: () => <AddContext mdxStoryNameToKey={mdxStoryNameToKey} mdxComponentAnnotations={componentMeta}><MDXContent /></AddContext>,
+  page: () => <MDXContent />,
 };
 `.trim();
 
@@ -505,13 +503,12 @@ function extractExports(root: Element, options: CompilerOptions) {
 
   const defaultJsx = toJSX(root, {}, { ...options, skipExport: true });
   const fullJsx = [
-    'import { assertIsFn, AddContext } from "@storybook/addon-docs";',
+    'import { assertIsFn } from "@storybook/addon-docs";',
     defaultJsx,
     ...storyExports,
     `const componentMeta = ${stringifyMeta(metaExport)};`,
-    `const mdxStoryNameToKey = ${JSON.stringify(context.storyNameToKey)};`,
     wrapperJs,
-    'export default componentMeta;',
+    'export default  ${stringifyMeta(metaExport)};;',
   ].join('\n\n');
 
   return fullJsx;


### PR DESCRIPTION
Issue: https://linear.app/chromaui/issue/SB-465/remove-call-to-addtemplate-from-mdx-generators

## What Changed

We longer need to add to the docs context in SB7, so we can simplify things a little.

## How to test

Build against a 7.0 alpha (not quite sure how to test TBH)