### PR TITLE
build(deps): move prettier to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "js-string-escape": "^1.0.1",
     "loader-utils": "^2.0.0",
     "lodash": "^4.17.21",
-    "prettier": ">=2.2.1 <=2.3.0",
     "ts-dedent": "^2.0.0"
   },
   "devDependencies": {
@@ -80,6 +79,7 @@
     "jest": "^27.0.6",
     "jest-environment-jsdom": "^27.0.6",
     "lint-staged": ">=10",
+    "prettier": ">=2.2.1 <=2.3.0",
     "prompts": "^2.4.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",


### PR DESCRIPTION
## What Changed

having prettier in the dependency list causes all packages using this package to download this version of prettier - causing possible version conflicts for formatting their own code

## How to test

run prettier - if it still works it works

## Change Type

- [x] `maintenance`
- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`
