### PR TITLE
ReDoS attack patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@mdx-js/react": "^1.6.22",
     "@types/lodash": "^4.14.167",
     "js-string-escape": "^1.0.1",
-    "loader-utils": "^2.0.0",
+    "loader-utils": "^2.0.4",
     "lodash": "^4.17.21",
     "prettier": ">=2.2.1 <=2.3.0",
     "ts-dedent": "^2.0.0"


### PR DESCRIPTION
Issue: #

## What Changed

Bump loader utils to 2.0.4. 
Affected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS)

## How to test

No testing is needed for this change. Unless this change does not play well with some of the existing dependency versions.

## Change Type

<!-- Indicate the type of change your pull request is: -->

- [ ] `maintenance`
- [ ] `documentation`
- [X] `patch`
- [ ] `minor`
- [ ] `major`
