### PR TITLE
Throw descriptive error when 'of' prop is detected

### DIFF
--- a/src/sb-mdx-plugin.test.ts
+++ b/src/sb-mdx-plugin.test.ts
@@ -802,6 +802,34 @@ describe('docs-mdx-compiler-plugin', () => {
     ).rejects.toThrow('Expected a Story name, id, or story attribute');
   });
 
+  it("errors on story 'of' prop", async () => {
+    await expect(async () =>
+      clean(dedent`
+        import * as MyStories from './My.stories';
+        import { Story, Meta } from '@storybook/addon-docs';
+
+        <Meta title="Button" />
+
+        # Bad story
+
+        <Story of={MyStories.Primary} />
+      `)
+    ).rejects.toThrow(`The 'of' prop is not supported in .stories.mdx files, only .mdx files.
+    See https://storybook.js.org/docs/7.0/react/writing-docs/mdx on how to write MDX files and stories separately.`);
+  });
+
+  it("errors on meta 'of' prop", async () => {
+    await expect(async () =>
+      clean(dedent`
+        import * as MyStories from './My.stories';
+        import { Meta } from '@storybook/addon-docs';
+
+        <Meta title="Button" of={MyStories} />
+      `)
+    ).rejects.toThrow(`The 'of' prop is not supported in .stories.mdx files, only .mdx files.
+    See https://storybook.js.org/docs/7.0/react/writing-docs/mdx on how to write MDX files and stories separately.`);
+  });
+
   describe('csf3', () => {
     it('auto-title-docs-only.mdx', () => {
       expect(

--- a/src/sb-mdx-plugin.ts
+++ b/src/sb-mdx-plugin.ts
@@ -135,6 +135,11 @@ const expressionOrNull = (attr: t.JSXAttribute['value']) =>
   t.isJSXExpressionContainer(attr) ? attr.expression : null;
 
 function genStoryExport(ast: t.JSXElement, context: Context) {
+  if (getAttr(ast.openingElement, 'of')) {
+    throw new Error(`The 'of' prop is not supported in .stories.mdx files, only .mdx files.
+    See https://storybook.js.org/docs/7.0/react/writing-docs/mdx on how to write MDX files and stories separately.`);
+  }
+
   const storyName = idOrNull(getAttr(ast.openingElement, 'name'));
   const storyId = idOrNull(getAttr(ast.openingElement, 'id'));
   const storyRef = getAttr(ast.openingElement, 'story') as t.JSXExpressionContainer;
@@ -277,6 +282,11 @@ function genCanvasExports(ast: t.JSXElement, context: Context) {
 }
 
 function genMeta(ast: t.JSXElement, options: CompilerOptions) {
+  if (getAttr(ast.openingElement, 'of')) {
+    throw new Error(`The 'of' prop is not supported in .stories.mdx files, only .mdx files.
+    See https://storybook.js.org/docs/7.0/react/writing-docs/mdx on how to write MDX files and stories separately.`);
+  }
+
   const titleAttr = getAttr(ast.openingElement, 'title');
   const idAttr = getAttr(ast.openingElement, 'id');
   let title = null;


### PR DESCRIPTION
Works on https://github.com/storybookjs/storybook/issues/20496

Mirror PR for MDX2: https://github.com/storybookjs/mdx2-csf/pull/37

## What Changed

This PR throws a descriptive error when the `of` prop on `Meta` or `Story` is found, as that is not supported in `.stories.mdx` files

<!-- Insert a description below. -->

## How to test

Add a file to a sandbox like this:

```
import { Story, Meta } from '@storybook/blocks';
import * as ButtonStories from './Button.stories';
import { Button } from './Button';

<Meta title="storiesMdx" component={Button}/>

<Story of={ButtonStories.Primary} />

```

or 

```
import { Story, Meta } from '@storybook/blocks';
import * as ButtonStories from './Button.stories';
import { Button } from './Button';

<Meta title="storiesMdx" of={ButtonStories} />

<Story story={ButtonStories.Primary} />

```

<!-- Add an explanation below for the reviewers to help them test your changes. -->

## Change Type

<!-- Indicate the type of change your pull request is: -->

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.5--canary.21.beb53e0.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/mdx1-csf@0.0.5--canary.21.beb53e0.0
  # or 
  yarn add @storybook/mdx1-csf@0.0.5--canary.21.beb53e0.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
